### PR TITLE
Update to zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "AFLplusplus",
+    .name = .AFLplusplus,
+    .fingerprint = 0x632e7eb6e1720d68,
     .version = "4.21.0",
-    .minimum_zig_version = "0.13.0",
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .AFLplusplus = .{
             .url = "https://github.com/AFLplusplus/AFLplusplus/archive/v4.21c.tar.gz",


### PR DESCRIPTION
This PR updates the `build.zig.zon` structure to be up to date with zig 0.14.0