### PR TITLE
Speed up actions by excluding paths from dpkg

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,9 @@ jobs:
 
       - name: Set up LLVM and Clang
         run: |
-          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
-          path-exclude /usr/share/doc/*
-          path-exclude /usr/share/man/*
-          path-exclude /usr/share/info/*
-          EOF
+          # Don't waste a bunch of time processing man-db triggers
+          echo "set man-db/auto-update false" | sudo debconf-communicate
+          sudo dpkg-reconfigure man-db
           sudo apt-get update
           sudo apt-get install -y lld llvm llvm-dev clang
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,11 @@ jobs:
 
       - name: Set up LLVM and Clang
         run: |
+          sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+          path-exclude /usr/share/doc/*
+          path-exclude /usr/share/man/*
+          path-exclude /usr/share/info/*
+          EOF
           sudo apt-get update
           sudo apt-get install -y lld llvm llvm-dev clang
 


### PR DESCRIPTION
ref: actions/runner-images#10977

man-db triggers take ages to execute after installing clang/llvm. By disabling the man-db auto-update, we can speed up the install significantly. When I saw it take such a long time to install ([1m43s](https://github.com/allyourcodebase/AFLplusplus/actions/runs/17698772572/job/50301606079)), I thought it was a bit absurd. With these changes, it took [21s](https://github.com/kylesower/AFLplusplus/actions/runs/17699135191/job/50302444808).